### PR TITLE
add new conversation_turns param

### DIFF
--- a/sdk/api/evaluation-task-service.mdx
+++ b/sdk/api/evaluation-task-service.mdx
@@ -140,6 +140,10 @@ The benefits of this approach include:
 - **Performance tracking**: You can track the performance of your product over time, allowing you to identify trends and make data-driven decisions.
 - **Analysis of inputs and outputs**: You can analyze the inputs and outputs of your product in a real-world context, which can help you understand how it is being used and identify areas for improvement.
 
+<Info>
+  See an example of running evaluation tasks of your product in production in our [Monitor Production Responses to User Queries example](/sdk/examples/monitor-production-responses-to-user-queries).
+</Info>
+
 ```python
 evaluation_task = galtea.evaluation_tasks.create_from_production(
     version_id="YOUR_VERSION_ID",
@@ -207,6 +211,9 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
       - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
       - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
  </Note>
+ <Info>
+ See an example of evaluating conversations in our [Monitor Production Responses to User Queries example](/sdk/examples/monitor-production-responses-to-user-queries#evaluating-conversations).
+ </Info>
 </ResponseField>
 
 <ResponseField name="latency" type="float">

--- a/sdk/api/evaluation-task-service.mdx
+++ b/sdk/api/evaluation-task-service.mdx
@@ -6,7 +6,7 @@ iconType: "solid"
 ---
 
 The Evaluation Task Service in the Galtea SDK allows you to manage [evaluation tasks](/concepts/product/evaluation/task) for assessing your products.
-This Service is exposed by the `galtea.evaluation_tasks` object and we will further explore its API down below.
+- This service is exposed via the `galtea.evaluation_tasks` object; see its API below.
 
 <Info>
   Remember that we will be using the `galtea` object. More information [here](/sdk/api/galtea).
@@ -36,7 +36,7 @@ evaluation_task = galtea.evaluation_tasks.create(
 <ResponseField name="metrics" type="list[string]" required>
   The metrics to use for the evaluation.
   <Note>
-    The system will create a task for each metric given.
+    The system will create a task for each metric provided.
   </Note>
 </ResponseField>
 
@@ -58,9 +58,9 @@ evaluation_task = galtea.evaluation_tasks.create(
 </ResponseField>
 
 <ResponseField name="conversation turns" type="list[dict[string, string]]">
-  The conversation turns that were used to generate the actual output as additional context for the model. Basically the conversation history (without the current user_query / model_answer).
+  The conversation turns used to generate the actual output provide additional context for the model. This represents the conversation history, excluding the current user query and model answer.
   This allows evaluation of the model's performance in a conversational context.
-  There is a expected format for the conversation turns:
+  There is an expected format for the conversation turns:
   ```json
   [
     {"input": "What is the capital of France?", "actual_output": "Paris"},
@@ -69,7 +69,7 @@ evaluation_task = galtea.evaluation_tasks.create(
   ```
 
   <Note>
-    Currently, this parameter can only be used with the following metrics, which available in the platform:
+    Currently, this parameter can only be used with the following metrics, which are available on the platform:
       - **Role Adherence**: Measures how well the actual output adheres to a specified role.
       - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
       - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
@@ -132,7 +132,7 @@ evaluation_task = galtea.evaluation_tasks.create(
 
 ## Monitoring User Interactions in Production
 
-If you want to monitor the user interactions for your application in production, you can do it simply by creating an evaluation task from the `input`s that your users are introducing to your system.
+- If you want to monitor user interactions in production, do so simply by creating an evaluation task from the inputs that your users send to your system.
 This way, you can evaluate your product using real-world data and continuously improve its performance.
 The benefits of this approach include:
 - **Real-world data**: You can evaluate your product using real-world data, which can provide more accurate insights into its performance.
@@ -170,7 +170,7 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
 <ResponseField name="metrics" type="list[string]" required>
   The metrics to use for the evaluation.
   <Note>
-    The system will create a task for each metric given.
+    The system will create a task for each metric provided.
   </Note>
 </ResponseField>
 
@@ -191,17 +191,17 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
 </ResponseField>
 
 <ResponseField name="conversation turns" type="list[dict[string, string]]">
-  The conversation turns that were used to generate the actual output as additional context for the model. Basically the conversation history (without the current user_query / model_answer).
+  The conversation turns used to generate the actual output provide additional context for the model. This represents the conversation history, excluding the current user query and model answer.
   This allows evaluation of the model's performance in a conversational context.
-  There is a expected format for the conversation turns:
+  There is an expected format for the conversation turns:
   ```json
   [
-    {"input": "What is the capital of France?", "actual_output": "Paris"},
-    {"input": "What is the population of it?", "actual_output": "two million"}
+    {"input": "What is the capital of France?", "actual_output": "Paris."},
+    {"input": "What is the population of it?", "actual_output": "Two million."}
   ]
   ```
   <Note>
-    Currently, this parameter can only be used with the following metrics, which available in the platform:
+    Currently, this parameter can only be used with the following metrics, which are available to all organizations:
       - **Role Adherence**: Measures how well the actual output adheres to a specified role.
       - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
       - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.

--- a/sdk/api/evaluation-task-service.mdx
+++ b/sdk/api/evaluation-task-service.mdx
@@ -57,6 +57,26 @@ evaluation_task = galtea.evaluation_tasks.create(
   </Note>
 </ResponseField>
 
+<ResponseField name="conversation turns" type="list[dict[string, string]]">
+  The conversation turns that were used to generate the actual output as additional context for the model. Basically the conversation history (without the current user_query / model_answer).
+  This allows evaluation of the model's performance in a conversational context.
+  There is a expected format for the conversation turns:
+  ```json
+  [
+    {"input": "What is the capital of France?", "actual_output": "Paris"},
+    {"input": "What is the population of it?", "actual_output": "two million"}
+  ]
+  ```
+
+  <Note>
+    Currently, this parameter is useful for these kind of default metrics available in the platform:
+    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+ </Note>
+</ResponseField>
+
 <ResponseField name="scores" type="list[float | None]">
   Precomputed scores for the evaluation tasks, corresponding to the provided metrics. Must be a list of the same size as the `metrics` parameter, containing numbers between 0 and 1 or `None` values.
     - Providing scores bypasses platform-based evaluation, storing the provided scores for later analysis. Useful for **custom metrics**.
@@ -128,6 +148,7 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
     actual_output=model_answer,
     retrieval_context=retrieved_context,
     context=conversation_context,
+    conversation_turns=[{"input": past_user_query, "actual_output": past_model_answer}],
     latency=latency,
     usage_info={
         "input_tokens": input_tokens,
@@ -167,6 +188,25 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
 
 <ResponseField name="retrieval_context" type="string">
   The context retrieved by your RAG system that was used to generate the actual output.
+</ResponseField>
+
+<ResponseField name="conversation turns" type="list[dict[string, string]]">
+  The conversation turns that were used to generate the actual output as additional context for the model. Basically the conversation history (without the current user_query / model_answer).
+  This allows evaluation of the model's performance in a conversational context.
+  There is a expected format for the conversation turns:
+  ```json
+  [
+    {"input": "What is the capital of France?", "actual_output": "Paris"},
+    {"input": "What is the population of it?", "actual_output": "two million"}
+  ]
+  ```
+  <Note>
+    Currently, this parameter is useful for these kind of default metrics available in the platform:
+    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+ </Note>
 </ResponseField>
 
 <ResponseField name="latency" type="float">

--- a/sdk/api/evaluation-task-service.mdx
+++ b/sdk/api/evaluation-task-service.mdx
@@ -69,11 +69,11 @@ evaluation_task = galtea.evaluation_tasks.create(
   ```
 
   <Note>
-    Currently, this parameter is useful for these kind of default metrics available in the platform:
-    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
-    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
-    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
-    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+    Currently, this parameter can only be used with the following metrics, which available in the platform:
+      - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+      - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+      - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+      - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
  </Note>
 </ResponseField>
 
@@ -201,11 +201,11 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
   ]
   ```
   <Note>
-    Currently, this parameter is useful for these kind of default metrics available in the platform:
-    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
-    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
-    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
-    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+    Currently, this parameter can only be used with the following metrics, which available in the platform:
+      - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+      - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+      - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+      - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
  </Note>
 </ResponseField>
 

--- a/sdk/api/evaluation-task-service.mdx
+++ b/sdk/api/evaluation-task-service.mdx
@@ -201,7 +201,7 @@ evaluation_task = galtea.evaluation_tasks.create_from_production(
   ]
   ```
   <Note>
-    Currently, this parameter can only be used with the following metrics, which are available to all organizations:
+    Currently, this parameter can only be used with the following metrics, which are available by default:
       - **Role Adherence**: Measures how well the actual output adheres to a specified role.
       - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
       - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.

--- a/sdk/examples/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/examples/monitor-production-responses-to-user-queries.mdx
@@ -57,7 +57,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
 
 <Info>
   The `conversation_turns` parameter allows you to create evaluation tasks with a real user conversation history.
-  For now, you can only use these default metrics for evaluating conversations:
+  Currently, this parameter can only be used with the following metrics, which available in the platform:
     - **Role Adherence**: Measures how well the actual output adheres to a specified role.
     - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
     - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.

--- a/sdk/examples/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/examples/monitor-production-responses-to-user-queries.mdx
@@ -57,7 +57,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
 
 ## Evaluating conversations
 
-To accurately **evaluate interactions within a dialogue**, certain metrics need access to the preceding turns of the conversation. This is handled by the conversation_turns parameter.
+To accurately **evaluate interactions within a dialogue**, certain metrics need access to the preceding turns of the conversation. This is handled by the [ `conversation_turns` parameter](/sdk/api/evaluation-task-service#param-conversation-turns-1).
 
 Currently, this parameter can only be used with the following metrics, which are available by default:
   - **Role Adherence**: Measures how well the actual output adheres to a specified role.
@@ -71,7 +71,7 @@ Currently, this parameter can only be used with the following metrics, which are
 The `conversation_turns` parameter expects a list of dictionaries. Each dictionary represents a **single, complete exchange** (one user query and the assistant's response to it) that occurred before the current interaction being sent to our platform.
 
 The required structure for each dictionary in the list is:
-```python
+```json
 {
   "input": "The user's query from that past turn",
   "actual_output": "The assistant's response from that past turn"

--- a/sdk/examples/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/examples/monitor-production-responses-to-user-queries.mdx
@@ -55,38 +55,75 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
   The `latency` and `usage_info` parameters are optional but highly recommended to keep track of the the real performance data of you product. 
 </Note>
 
-<Info>
-  The `conversation_turns` parameter allows you to create evaluation tasks with a real user conversation history.
-  Currently, this parameter can only be used with the following metrics, which available in the platform:
-    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
-    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
-    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
-    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+## Evaluating conversations
 
-How Can you convert your conversation history to the format that the conversation_turns parameter expects?
+To accurately **evaluate interactions within a dialogue**, certain metrics need access to the preceding turns of the conversation. This is handled by the conversation_turns parameter.
 
-Let's say you have a conversation history like this.
+Currently, this parameter can only be used with the following metrics, which available in the platform:
+  - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+  - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+  - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+  - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+
+
+### Expected format
+
+The `conversation_turns` parameter expects a list of dictionaries. Each dictionary represents a **single, complete exchange** (one user query and the assistant's response to it) that occurred before the current interaction being sent to our platform.
+
+The required structure for each dictionary in the list is:
 ```python
-conversation_history = [ 
-  {'role': 'system',  'content': 'You speak like a pirate.'},
-  {'role': 'user', 'content': 'Can you teach me to swim?'},
-  {'role': 'assistant', 'content': 'Sure thing, matey! Then ye go swim with the shark.'}
-]
-extract_conversation_turns(conversation_history)
+{
+  "input": "The user's query from that past turn",
+  "actual_output": "The assistant's response from that past turn"
+}
 ```
 
-And this would be the method definition to extract the conversation turns:
+This is how it would look like in practice:
 ```python
-def extract_conversation_turns(messages):
+# Example: conversation_turns list passed to create_from_production
+[
+  {"input": "Hi, tell me about Galtea.", "actual_output": "Galtea is an AI evaluation platform."},
+  {"input": "What metrics does it support?", "actual_output": "It supports accuracy, relevance, safety metrics, and more."},
+  # ... other past turns in chronological order ...
+]
+```
+
+### Converting Your Application's History Format
+
+Let's say you have a conversation history like this.
+
+```python
+conversation_history = [
+  {'system': 'system', 'content': 'You are a pirate.'},
+  {'role': 'user', 'content': 'Can you teach me to swim?'},
+  {'role': 'assistant', 'content': 'Sure thing, matey! Then ye go swim with the shark.'},
+  {'role': 'user', 'content': 'I am not sure if I can swim with the shark.'},
+  {'role': 'assistant', 'content': 'Ye can do it!'},
+]
+```
+
+This could be the method definition to extract the conversation turns from the conversation history:
+```python
+def extract_conversation_turns(messages: list[dict]) -> list[dict]:
   conversation_turns = []
   user_query = None
   for message in messages:
-      if message['role'] == 'user':
-          user_query = message['content']
-      elif message['role'] == 'assistant' and user_query is not None:
-          conversation_turns.append({"input": user_query, "actual_output":message['content']})
-          user_query = None
-  
+    # Skip system messages or irrelevant roles if necessary
+    if message['role'] == 'system':
+        continue
+
+    if message['role'] == 'user':
+        # Store the user query temporarily
+        user_query = message['content']
+    elif message['role'] == 'assistant' and user_query is not None:
+        # Found an assistant response following a user query, form a turn
+        conversation_turns.append({
+            "input": user_query,
+            "actual_output": message['content']
+        })
+        # Reset user_query to wait for the next user message
+        user_query = None
+    # Handle edge cases: consecutive user/assistant messages if applicable
+
   return conversation_turns
 ```
-</Info>

--- a/sdk/examples/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/examples/monitor-production-responses-to-user-queries.mdx
@@ -59,7 +59,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
 
 To accurately **evaluate interactions within a dialogue**, certain metrics need access to the preceding turns of the conversation. This is handled by the conversation_turns parameter.
 
-Currently, this parameter can only be used with the following metrics, which available in the platform:
+Currently, this parameter can only be used with the following metrics, which are available by default:
   - **Role Adherence**: Measures how well the actual output adheres to a specified role.
   - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
   - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
@@ -101,8 +101,7 @@ conversation_history = [
   {'role': 'assistant', 'content': 'Ye can do it!'},
 ]
 ```
-
-This could be the method definition to extract the conversation turns from the conversation history:
+Then, this would be a valid method to extract the conversation turns from the conversation history:
 ```python
 def extract_conversation_turns(messages: list[dict]) -> list[dict]:
   conversation_turns = []

--- a/sdk/examples/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/examples/monitor-production-responses-to-user-queries.mdx
@@ -36,6 +36,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
   actual_output=response,
   retrieval_context=retrieval_context,
   context=context,
+  conversation_turns=extract_conversation_turns(conversation_history),
   usage_info={
     "input_tokens": response.input_tokens,
     "output_tokens": response.output_tokens,
@@ -53,3 +54,39 @@ evaluation_tasks = galtea.evaluation_tasks.create_from_production(
   
   The `latency` and `usage_info` parameters are optional but highly recommended to keep track of the the real performance data of you product. 
 </Note>
+
+<Info>
+  The `conversation_turns` parameter allows you to create evaluation tasks with a real user conversation history.
+  For now, you can only use these default metrics for evaluating conversations:
+    - **Role Adherence**: Measures how well the actual output adheres to a specified role.
+    - **Knowledge Retention**: Assesses the model's ability to retain and use information from previous turns in the conversation.
+    - **Conversation Completeness**: Evaluates whether the conversation has reached a natural and informative conclusion.
+    - **Conversation Relevancy**: Assesses whether each turn in the conversation is relevant to the ongoing topic and user needs.
+
+How Can you convert your conversation history to the format that the conversation_turns parameter expects?
+
+Let's say you have a conversation history like this.
+```python
+conversation_history = [ 
+  {'role': 'system',  'content': 'You speak like a pirate.'},
+  {'role': 'user', 'content': 'Can you teach me to swim?'},
+  {'role': 'assistant', 'content': 'Sure thing, matey! Then ye go swim with the shark.'}
+]
+extract_conversation_turns(conversation_history)
+```
+
+And this would be the method definition to extract the conversation turns:
+```python
+def extract_conversation_turns(messages):
+  conversation_turns = []
+  user_query = None
+  for message in messages:
+      if message['role'] == 'user':
+          user_query = message['content']
+      elif message['role'] == 'assistant' and user_query is not None:
+          conversation_turns.append({"input": user_query, "actual_output":message['content']})
+          user_query = None
+  
+  return conversation_turns
+```
+</Info>

--- a/snippets/changelog/2025-05-12.html
+++ b/snippets/changelog/2025-05-12.html
@@ -23,7 +23,7 @@
                 <br />
                 <h3 style="color: #333">New Conversation Evaluation Metrics</h3>
                 <p style="color: #444; font-size: 16px">
-                  You can now evaluate conversations with greater precision using these new metrics:
+                  You can now <a href="https://docs.galtea.ai/sdk/examples/monitor-production-responses-to-user-queries#evaluating-conversations" style="color: #5c5bdd; text-decoration: underline">evaluate conversations</a> with greater precision using these new metrics:
                 </p>
                 <ul style="color: #444; font-size: 16px">
                   <li><strong>Role Adherence</strong> - Assess how well an AI stays within its defined role</li>
@@ -34,9 +34,7 @@
 
                 <br />
                 <h3 style="color: #333">Enhanced Security Framework</h3>
-                <p style="color: #444; font-size: 16px">
-                  We've significantly improved user access management by implementing an <strong>Attribute-Based Access Control (ABAC)</strong> strategy, providing more granular control over who can access what within your organization.
-                </p>
+                <p style="color: #444; font-size: 16px">We've significantly improved user access management by implementing an <strong>Attribute-Based Access Control (ABAC)</strong> strategy, providing more granular control over who can access what within your organization.</p>
 
                 <br />
                 <h3 style="color: #333">Extended Data Generation Capabilities</h3>
@@ -48,9 +46,7 @@
 
                 <br />
                 <h3 style="color: #333">Improved Test Creation Experience</h3>
-                <p style="color: #444; font-size: 16px">
-                  We've enhanced the clarity of threat selection in the Test Creation form. The selection now displays both the threat and which security frameworks that threat covers, making it easier to align your testing with specific security standards.
-                </p>
+                <p style="color: #444; font-size: 16px">We've enhanced the clarity of threat selection in the Test Creation form. The selection now displays both the threat and which security frameworks that threat covers, making it easier to align your testing with specific security standards.</p>
                 <div style="text-align: center; margin: 10px 0">
                   <img src="https://mintlify.s3.us-west-1.amazonaws.com/galtea/images/changelog/2025-05-12_improved_threat_selection.png" alt="Improved Threat Selection" style="max-width: 100%; height: auto; border-radius: 8px" />
                 </div>

--- a/snippets/changelog/2025-05-12.mdx
+++ b/snippets/changelog/2025-05-12.mdx
@@ -2,7 +2,7 @@
 
 ## New Conversation Evaluation Metrics
 
-You can now evaluate conversations with greater precision using these new metrics:
+You can now [evaluate conversations](/sdk/examples/monitor-production-responses-to-user-queries#evaluating-conversations) using these new metrics:
 - **Role Adherence** - Assess how well an AI stays within its defined role
 - **Knowledge Retention** - Measure how effectively information is remembered throughout a conversation
 - **Conversation Completeness** - Evaluate whether all user queries were fully addressed


### PR DESCRIPTION
https://github.com/Galtea-AI/roadmap/issues/60.

We are adding documentation about thew new conversation_turns parameter in evaluation tasks that allows users to create an evaluation taking into account the whole conversation history.