### PR TITLE
Add BLEU, ROUGE, METEOR and Jailbreak Resilience v2 metrics. 

### DIFF
--- a/concepts/metric-type.mdx
+++ b/concepts/metric-type.mdx
@@ -61,6 +61,9 @@ At Galtea, we use two types of metrics to evaluate large language model (LLM) ou
 | **[Contextual Precision](/concepts/metric-type/contextual-precision)** | RAG | Measures your RAG pipeline's retriever by evaluating whether nodes in your retrieval_context that are relevant to the given input are ranked higher than irrelevant ones. |
 | **[Contextual Recall](/concepts/metric-type/contextual-recall)** | RAG | Measures the quality of your RAG pipeline's retriever by evaluating the extent of which the retrieval_context aligns with the expected_output. |
 | **[Contextual Relevancy](/concepts/metric-type/contextual-relevancy)** | RAG | Measures the quality of your RAG pipeline's retriever by evaluating the overall relevance of the information presented in your retrieval_context for a given input. |
+| **[BLEU](/concepts/metric-type/bleu)** | RAG | Measures how many n-grams in the actual output overlap with those in a set of expected output. |
+| **[ROUGE](/concepts/metric-type/rouge)** | RAG | Evaluates automatic summarization by measuring the longest common subsequence that preserves the word order between actual output and expected output summaries. |
+| **[METEOR](/concepts/metric-type/meteor)** | RAG | Evaluates translation, summarization, and paraphrasing by aligning words using exact matches, stems, or synonyms. |
 | **[Role Adherence](/concepts/metric-type/role-adherence)** | Conversational | Determines whether your LLM chatbot is able to adhere to its given role throughout a conversation. |
 | **[Conversation Completeness](/concepts/metric-type/conversation-completeness)** | Conversational | Determines whether your LLM chatbot is able to complete an end-to-end conversation by satisfying user needs throughout a conversation. |
 | **[Conversation Relevancy](/concepts/metric-type/conversation-relevancy)** | Conversational | Determines whether your LLM chatbot is able to consistently generate relevant responses throughout a conversation. |
@@ -69,6 +72,8 @@ At Galtea, we use two types of metrics to evaluate large language model (LLM) ou
 | **[Unbiased](/concepts/metric-type/unbiased)** | Red Teaming | Determine whether your LLM output is free of gender, racial, or political bias. |
 | **[Misuse Resilience](/concepts/metric-type/misuse-resilience)** | Red Teaming | Evaluates whether the generated output is resilient to misuse and remains aligned with the product description. |
 | **[Data Leakage](/concepts/metric-type/data-leakage)** | Red Teaming | Evaluates whether the LLM returns content that may include sensitive information. |
+| **[Jailbreak Resilience v2](/concepts/metric-type/jailbreak-resilience-v2)** | Red Teaming | Evaluates the ability of an LLM-based product to resist attempts at breaking or manipulating its intended behavior. |
+
 
 ## Metric Type Properties
 

--- a/concepts/metric-type/bleu.mdx
+++ b/concepts/metric-type/bleu.mdx
@@ -1,0 +1,65 @@
+---
+title: "BLEU"
+description: "Primarily used for machine translation evaluation, measuring how many n-grams (phrases of n words) in the candidate translation overlap with those in a set of reference translations."
+---
+The BLEU (bilingual evaluation understudy) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes to objectively compare a model’s output against ground‑truth references. It is most appropriate when you expect the model to reproduce wording very close to the reference (e.g., machine translation or tightly constrained generation).
+
+---
+## Evaluation Parameters
+
+To compute the `bleu` metric, the following parameters are required:
+
+- **`actual_output`**: The model’s generated text.
+- **`expected_output`**: The reference (or gold) text to compare against.
+
+---
+## How Is It Calculated?
+
+Conceptually, BLEU is computed as:
+
+1. **N‑gram Precision**  
+   Compute modified precision for n‑grams of sizes **1, 2, 3, and 4**: how many of the candidate’s n‑grams also appear in the reference(s), clipped by the maximum count in the references.
+
+2. **Geometric Mean of Precisions**  
+   Combine the n‑gram precisions with a geometric mean to balance contributions from different n‑gram sizes.
+
+3. **Brevity Penalty (BP)**  
+   Penalize overly short candidates:
+   \[
+   \text{BP} =
+     \begin{cases}
+       1 & \text{if } c > r \\
+       e^{(1 - r/c)} & \text{if } c \le r
+     \end{cases}
+   \]
+   where \(c\) is candidate length and \(r\) is reference length.
+
+4. **Final Score**  
+   \[
+   \text{BLEU} = \text{BP} \times \exp\left(\sum_{n=1}^{4} w_n \log p_n\right)
+   \]
+   where \(p_n\) are the modified n‑gram precisions and \(w_n\) are their weights (often uniform, \(w_n = \frac{1}{4}\)).
+
+
+BLEU returns a value between **0 and 1** in this implementation.
+
+- **≥ 0.6** – Very strong overlap / near-reference quality.
+- **0.3 – 0.6** – Moderate overlap; acceptable for some machine translation tasks.
+- **< 0.3** – Low overlap; likely poor or very different phrasing.
+
+
+---
+## Suggested Test Case Types
+
+Use BLEU when you have **deterministic, reference-style outputs**, such as:
+
+- **Machine Translation** (primary use case).
+- **Data-to-Text Generation** where the wording is tightly constrained.
+- **Template-like Summaries or Headline Generation** where near-exact phrasing matters.
+- **Paraphrase Detection (strict)** when you want to reward lexical overlap (with caution).
+
+---
+## Related Topics
+
+- [ROUGE](/concepts/metric-type/rouge)
+- [METEOR](/concepts/metric-type/meteor)

--- a/concepts/metric-type/bleu.mdx
+++ b/concepts/metric-type/bleu.mdx
@@ -25,20 +25,23 @@ Conceptually, BLEU is computed as:
 
 3. **Brevity Penalty (BP)**  
    Penalize overly short candidates:
-   \[
-   \text{BP} =
+
+   $$
+   BP =
      \begin{cases}
        1 & \text{if } c > r \\
-       e^{(1 - r/c)} & \text{if } c \le r
+       e^{(1 - \frac{r}{c})} & \text{if } c \le r
      \end{cases}
-   \]
-   where \(c\) is candidate length and \(r\) is reference length.
+   $$
 
-4. **Final Score**  
-   \[
-   \text{BLEU} = \text{BP} \times \exp\left(\sum_{n=1}^{4} w_n \log p_n\right)
-   \]
-   where \(p_n\) are the modified n‑gram precisions and \(w_n\) are their weights (often uniform, \(w_n = \frac{1}{4}\)).
+   where $c$ is candidate length and $r$ is reference length.
+
+4. **Final Score**
+   $$
+   BLEU = BP \cdot \exp\left(\sum_{n=1}^{4} w_n \log p_n \right)
+   $$
+
+   where $p_n$ are the modified n‑gram precisions and $w_n$ are their weights (uniform, $w_n = \frac{1}{4}$ \).
 
 
 BLEU returns a value between **0 and 1** in this implementation.

--- a/concepts/metric-type/jailbreak-resilience-v2.mdx
+++ b/concepts/metric-type/jailbreak-resilience-v2.mdx
@@ -38,6 +38,7 @@ The final score is assigned based on the model's resistance to the jailbreak att
 
 <Note>This metric evaluates effectiveness (resistance quality), robustness (consistency across attack types), and safety (protection against malicious use) to provide comprehensive jailbreak resilience assessment.</Note>
 
+---
 ## Suggested Test Case Types
 
 The Jailbreak Resilience metric is effective for evaluating multiple types of threats that attempt to bypass safety mechanisms:

--- a/concepts/metric-type/meteor.mdx
+++ b/concepts/metric-type/meteor.mdx
@@ -31,10 +31,10 @@ METEOR improves upon [BLEU](/concepts/metric-type/bleu) by considering **semanti
 
 4. **Final Score**  
    The score is computed as:
-   \[
-   METEOR = F_{mean} \cdot (1 - Penalty)
-   \]
-   where \(F_{mean}\) is the harmonic mean of precision and recall.
+   ```
+   METEOR = F_mean × (1 - Penalty)
+   ```
+   where F_mean is the harmonic mean of precision and recall.
 
 
 METEOR returns a score between **0 and 1**:

--- a/concepts/metric-type/meteor.mdx
+++ b/concepts/metric-type/meteor.mdx
@@ -31,9 +31,9 @@ METEOR improves upon [BLEU](/concepts/metric-type/bleu) by considering **semanti
 
 4. **Final Score**  
    The score is computed as:
-   ```
-   METEOR = F_mean × (1 - Penalty)
-   ```
+   $$
+   METEOR = F_{mean} \times (1 - Penalty)
+   $$
    where F_mean is the harmonic mean of precision and recall.
 
 

--- a/concepts/metric-type/meteor.mdx
+++ b/concepts/metric-type/meteor.mdx
@@ -2,7 +2,7 @@
 title: "METEOR"
 description: "Evaluates translation, summarization, and paraphrasing by aligning words using exact matches, stems, or synonyms, computing precision and recall."
 ---
-The **METEOR** (Metric for Evaluation of Translation with Explicit ORdering) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes for evaluating machine translation, summarization, and paraphrasing tasks. It aims to correlate more closely with human judgments compared to [BLEU](/concepts/metric-type/bleu).
+The METEOR (Metric for Evaluation of Translation with Explicit ORdering) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes for evaluating machine translation, summarization, and paraphrasing tasks. It aims to correlate more closely with human judgments compared to [BLEU](/concepts/metric-type/bleu).
 
 ---
 ## Evaluation Parameters

--- a/concepts/metric-type/meteor.mdx
+++ b/concepts/metric-type/meteor.mdx
@@ -1,0 +1,59 @@
+---
+title: "METEOR"
+description: "Evaluates translation, summarization, and paraphrasing by aligning words using exact matches, stems, or synonyms, computing precision and recall."
+---
+The **METEOR** (Metric for Evaluation of Translation with Explicit ORdering) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes for evaluating machine translation, summarization, and paraphrasing tasks. It aims to correlate more closely with human judgments compared to [BLEU](/concepts/metric-type/bleu).
+
+---
+## Evaluation Parameters
+
+To compute the `meteor` metric, the following parameters are required:
+
+- **`actual_output`**: The model’s generated text.
+- **`expected_output`**: The reference (or gold) text to compare against.
+
+---
+## How Is It Calculated?
+
+METEOR improves upon [BLEU](/concepts/metric-type/bleu) by considering **semantic and morphological matches**:
+
+1. **Alignment**  
+   Tokens are matched between candidate and reference using:
+   - **Exact matches**
+   - **Stems** (e.g., "run" vs. "running")
+   - **Synonyms** (e.g., "big" vs. "large")
+
+2. **Precision & Recall**  
+   Both are calculated from the aligned tokens.
+
+3. **Fragmentation Penalty**  
+   A penalty is applied if matches are scattered (fragmented alignment).
+
+4. **Final Score**  
+   The score is computed as:
+   \[
+   METEOR = F_{mean} \cdot (1 - Penalty)
+   \]
+   where \(F_{mean}\) is the harmonic mean of precision and recall.
+
+
+METEOR returns a score between **0 and 1**:
+
+- **≥ 0.6** – High-quality translation/summary with semantic fidelity.
+- **0.3 – 0.6** – Moderate quality; some paraphrasing or structural divergence.
+- **< 0.3** – Low-quality or semantically incorrect output.
+
+---
+## Suggested Test Case Types
+
+Use METEOR when evaluating:
+
+- **Machine Translation** with varied phrasings.
+- **Abstractive Summarization** where synonyms are common.
+- **Paraphrase Detection** with semantic variation.
+
+---
+## Related Topics
+
+- [BLEU](/concepts/metric-type/bleu)
+- [ROUGE](/concepts/metric-type/rouge)

--- a/concepts/metric-type/rouge.mdx
+++ b/concepts/metric-type/rouge.mdx
@@ -2,7 +2,7 @@
 title: "ROUGE"
 description: "Evaluates automatic summarization by measuring the longest common subsequence (LCS) that preserves the word order between candidate and reference summaries." 
 ---
-The **ROUGE** (Recall-Oriented Understudy for Gisting Evaluation) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes to evaluate how well a generated summary captures the content of a reference summary. It is primarily used for **summarization tasks** and other scenarios where recall is more important than exact lexical match.
+The ROUGE (Recall-Oriented Understudy for Gisting Evaluation) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes to evaluate how well a generated summary captures the content of a reference summary. It is primarily used for summarization tasks and other scenarios where recall is more important than exact lexical match.
 
 ---
 ## Evaluation Parameters

--- a/concepts/metric-type/rouge.mdx
+++ b/concepts/metric-type/rouge.mdx
@@ -26,10 +26,9 @@ This implementation uses **ROUGE-L**, which focuses on the **Longest Common Subs
 
 3. **F1 Score**  
    Combines precision and recall:  
-   ```
-   F1 = (1 + β²) × P × R / (R + β² × P)
-   ```
-   with β = 1 for equal weighting.
+   $$
+   F1 = 2 \cdot \frac{P \times R}{R+P} 
+   $$
 
 
 ROUGE-L returns a score between **0 and 1**:

--- a/concepts/metric-type/rouge.mdx
+++ b/concepts/metric-type/rouge.mdx
@@ -1,0 +1,54 @@
+---
+title: "ROUGE"
+description: "Evaluates automatic summarization by measuring the longest common subsequence (LCS) that preserves the word order between candidate and reference summaries." 
+---
+The **ROUGE** (Recall-Oriented Understudy for Gisting Evaluation) metric is one of the [Classic Metric Type](/concepts/metric-type) Galtea exposes to evaluate how well a generated summary captures the content of a reference summary. It is primarily used for **summarization tasks** and other scenarios where recall is more important than exact lexical match.
+
+---
+## Evaluation Parameters
+
+To compute the `rouge` metric, the following parameters are required:
+
+- **`actual_output`**: The model’s generated summary.
+- **`expected_output`**: The reference (or gold) summary to compare against.
+
+---
+## How Is It Calculated?
+
+This implementation uses **ROUGE-L**, which focuses on the **Longest Common Subsequence (LCS)** between the candidate and reference:
+
+1. **Longest Common Subsequence**  
+   Identifies the longest sequence of words that appears in both candidate and reference (not necessarily contiguous, but in the same order).
+
+2. **Precision & Recall**  
+   - **Precision (P)** = LCS length / candidate length  
+   - **Recall (R)** = LCS length / reference length
+
+3. **F1 Score**  
+   Combines precision and recall:  
+   \[
+   F1 = \frac{(1 + \beta^2) \cdot P \cdot R}{R + \beta^2 \cdot P}
+   \]
+   with \(\beta = 1\) for equal weighting.
+
+
+ROUGE-L returns a score between **0 and 1**:
+
+- **≥ 0.5** – Strong overlap with the reference summary.
+- **0.3 – 0.5** – Moderate overlap; acceptable for abstractive summarization.
+- **< 0.3** – Weak overlap; likely missing key content.
+
+---
+## Suggested Test Case Types
+
+Use ROUGE when evaluating:
+
+- **Abstractive or extractive summaries**.
+- **Headline generation** where recall of important tokens matters.
+- **Content coverage tests** for long text generation.
+
+---
+## Related Topics
+
+- [BLEU](/concepts/metric-type/bleu)
+- [METEOR](/concepts/metric-type/meteor)

--- a/concepts/metric-type/rouge.mdx
+++ b/concepts/metric-type/rouge.mdx
@@ -26,10 +26,10 @@ This implementation uses **ROUGE-L**, which focuses on the **Longest Common Subs
 
 3. **F1 Score**  
    Combines precision and recall:  
-   \[
-   F1 = \frac{(1 + \beta^2) \cdot P \cdot R}{R + \beta^2 \cdot P}
-   \]
-   with \(\beta = 1\) for equal weighting.
+   ```
+   F1 = (1 + β²) × P × R / (R + β² × P)
+   ```
+   with β = 1 for equal weighting.
 
 
 ROUGE-L returns a score between **0 and 1**:

--- a/docs.json
+++ b/docs.json
@@ -67,7 +67,10 @@
                   "concepts/metric-type/faithfulness",
                   "concepts/metric-type/contextual-precision",
                   "concepts/metric-type/contextual-recall",
-                  "concepts/metric-type/contextual-relevancy"
+                  "concepts/metric-type/contextual-relevancy",
+                  "concepts/metric-type/bleu",
+                  "concepts/metric-type/rouge",
+                  "concepts/metric-type/meteor"
                 ]
               },
               {
@@ -78,7 +81,7 @@
               {
                 "group": "Red Teaming",
                 "icon": "shield-check",
-                "pages": ["concepts/metric-type/misuse-resilience", "concepts/metric-type/non-toxic", "concepts/metric-type/unbiased", "concepts/metric-type/jailbreak-resilience", "concepts/metric-type/data-leakage"]
+                "pages": ["concepts/metric-type/misuse-resilience", "concepts/metric-type/non-toxic", "concepts/metric-type/unbiased", "concepts/metric-type/jailbreak-resilience-v2", "concepts/metric-type/data-leakage"]
               }
             ]
           },


### PR DESCRIPTION
- Update docs.json to include BLEU, ROUGE and METEOR. Also modify jailbreak-resilience to jailbreak-resilience-v2 to use the new version of this metric.
- Add metric type description of BLEU, ROUGE and METEOR. For jailbreak resilience v2 was already done from last week.
- Add BLEU, ROUGE and METEOR as RAG metrics to metric-type.mdx. Add also Jailbreak Resilience v2 here.

# Pull Request Checklist
- [ ] I have referenced the issue in the PR [description (or comments)](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I have requested a reviewer to this PR.
- [ ] I have added myself as the assignee.
- [ ] Added `hotfix` label if this PR is a critical fix that needs to be merged without approval.
