### PR TITLE
Standardize metric names to title case in docs

### DIFF
--- a/sdk/api/evaluation-task/create-single-turn.mdx
+++ b/sdk/api/evaluation-task/create-single-turn.mdx
@@ -40,7 +40,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_single_turn(
     test_case_id="YOUR_TEST_CASE_ID",
     actual_output="The capital of France is Paris.",
     metrics=[
-        "coherence",            # Standard metric
+        "Coherence",            # Standard metric
         custom_score_accuracy   # Your custom metric object
     ]
 )
@@ -53,7 +53,7 @@ evaluation_tasks = galtea.evaluation_tasks.create_single_turn(
     is_production=True,
     input="A real user's query from production",
     actual_output="The model's live response.",
-    metrics=["relevance", "non-toxic"],
+    metrics=["Relevance", "Non-Toxic"],
     retrieval_context="Context retrieved by RAG for this query."
 )
 ```

--- a/sdk/api/evaluation-task/create.mdx
+++ b/sdk/api/evaluation-task/create.mdx
@@ -26,7 +26,7 @@ galtea.inference_results.create_batch(
 # Now, evaluate the entire session
 evaluation_tasks = galtea.evaluation_tasks.create(
     session_id=session.id,
-    metrics=["coherence", "conversation-relevancy"]
+    metrics=["Coherence", "Conversation Relevancy"]
 )
 ```
 

--- a/sdk/tutorials/create-evaluation-with-custom-scores.mdx
+++ b/sdk/tutorials/create-evaluation-with-custom-scores.mdx
@@ -58,7 +58,7 @@ galtea.evaluation_tasks.create_single_turn(
     test_case_id=TEST_CASE_ID,
     actual_output=actual_output,
     metrics=[
-        "coherence",     # A standard metric
+        "Coherence",     # A standard metric
         accuracy_metric  # Your custom metric object
     ],
 )

--- a/sdk/tutorials/evaluating-conversations.mdx
+++ b/sdk/tutorials/evaluating-conversations.mdx
@@ -44,8 +44,8 @@ galtea = Galtea(api_key=os.getenv("GALTEA_API_KEY"))
 YOUR_VERSION_ID = "your_version_id"
 YOUR_TEST_CASE_ID = "your_test_case_id"
 CONVERSATIONAL_METRICS = [
-    "role-adherence",
-    "knowledge-retention",
+    "Role Adherence",
+    "Knowledge Retention",
 ]
 
 # 1. Create a Session linked to a test case

--- a/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
@@ -26,7 +26,7 @@ def handle_user_query(user_query, retrieval_context=None):
     galtea.evaluation_tasks.create_single_turn(
       version_id=VERSION_ID,
       is_production=True,
-      metrics=["coherence", "answer-relevancy", "faithfulness"],
+      metrics=["Coherence", "Answer Relevancy", "Faithfulness"],
       input=user_query,
       actual_output=model_response,
       retrieval_context=retrieval_context
@@ -50,8 +50,11 @@ import os
 galtea = Galtea(api_key=os.getenv("GALTEA_API_KEY"))
 VERSION_ID = "YOUR_ACTIVE_VERSION_ID"
 METRICS_TO_EVALUATE = [
-    "conversation-relevancy",
-    "knowledge-retention"
+    "Conversation Relevancy",
+    "Knowledge Retention
+
+
+"
 ]
 
 # Use is_production=True for real user interactions

--- a/sdk/tutorials/simulating-conversations.mdx
+++ b/sdk/tutorials/simulating-conversations.mdx
@@ -124,7 +124,7 @@ for test_case in test_cases:
 ```python
 evaluation_tasks = galtea_client.evaluation_tasks.create(
     session_id=session.id,
-    metrics=["Factual Accuracy", "coherence"],  # Replace with your metrics
+    metrics=["Factual Accuracy", "Coherence"],  # Replace with your metrics
 )
 for task in evaluation_tasks:
     print(f"Evaluation task created: {task.id}")


### PR DESCRIPTION
Updated all code examples to use title case for metric names (e.g., 'Coherence', 'Relevance', 'Role Adherence') for consistency and clarity across API and tutorial documentation.
