### PR TITLE
User Satisfaction and User Objective Accomplished - new metrics

### DIFF
--- a/concepts/metric.mdx
+++ b/concepts/metric.mdx
@@ -74,6 +74,8 @@ At Galtea, we use two types of metrics to evaluate large language model (LLM) ou
 | **[Conversation Completeness](/concepts/metric/conversation-completeness)** | Conversational | Determines whether your LLM chatbot is able to complete an end-to-end conversation by satisfying user needs throughout a conversation. |
 | **[Conversation Relevancy](/concepts/metric/conversation-relevancy)** | Conversational | Determines whether your LLM chatbot is able to consistently generate relevant responses throughout a conversation. |
 | **[Knowledge Retention](/concepts/metric/knowledge-retention)** | Conversational | Assesses the ability of your LLM chatbot to retain factual information presented throughout a conversation. |
+| **[User Satisfaction](/concepts/metric/user-satisfaction)** | Conversational | Evaluates how satisfied the user was with the chatbot interaction, focusing on efficiency and user sentiment. |
+| **[User Objective Accomplished](/concepts/metric/user-objective-accomplished)** | Conversational | Evaluates whether the chatbot successfully and correctly fulfilled the user's stated objective, optionally verifying against an expected_output. |
 | **[Non-Toxic](/concepts/metric/non-toxic)** | Red Teaming | Determines whether the responses of your LLM based product responds are free of toxic language. |
 | **[Unbiased](/concepts/metric/unbiased)** | Red Teaming | Determine whether your LLM output is free of gender, racial, or political bias. |
 | **[Misuse Resilience](/concepts/metric/misuse-resilience)** | Red Teaming | Evaluates whether the generated output is resilient to misuse and remains aligned with the product description. |

--- a/concepts/metric/user-objective-accomplished.mdx
+++ b/concepts/metric/user-objective-accomplished.mdx
@@ -1,0 +1,44 @@
+title: "User Objective Accomplished"
+description: "Evaluates whether the user's stated objective was successfully and correctly achieved during the conversation."
+---
+
+The **User Objective Accomplished** metric is one of several [non-deterministic Metrics](/concepts/metric) Galtea uses to evaluate whether a conversation led to the user’s intended goal being fulfilled. Unlike satisfaction-based measures, this metric centers on *objective correctness*—whether the agent actually met the user’s stated objective.  
+
+Because LLMs often produce responses that *sound correct* even when they are not, this metric emphasizes verifying factual and goal-aligned outcomes, optionally using an `expected_output` when available. This ensures that evaluation is not based solely on conversational flow, but on actual task completion.  
+
+This metric is particularly useful for use cases where accuracy and goal fulfillment matter more than tone or fluency, such as customer support resolutions, fact-based Q&A, or task execution scenarios.
+
+---
+
+## Evaluation Parameters
+
+To compute the `user_objective_accomplished` metric, the following parameters are required:
+
+- **`goal`**: The stated objective or intent of the user.  
+- **`conversation_turns`**: The complete history of user inputs and chatbot responses.  
+
+Additionally, an **optional parameter** can be included:  
+
+- **`expected_output`**: A ground-truth answer that can be used to verify correctness. If not provided, evaluation is based solely on whether the conversation indicates the user’s objective was achieved.  
+
+---
+
+## How Is It Calculated?
+
+The `user_objective_accomplished` score is derived using an LLM-as-a-judge approach with strict correctness criteria:
+
+1. **Goal Identification**: Determine the user’s stated objective.  
+2. **Agent Response Evaluation**: Analyze how the agent attempted to fulfill the goal.  
+3. **Correctness Check**: If an `expected_output` is provided, confirm that the agent’s response aligns exactly with it. If not, rely on the conversational outcome to judge whether the user’s objective was achieved.  
+
+Based on this process, the LLM assigns a **binary score**:
+
+- **1 (Accomplished):** The agent successfully and correctly fulfilled the user’s objective. 
+- **0 (Not Accomplished):** The agent failed to fulfill the user’s objective.
+
+---
+
+## Related Topics
+
+- [User Satisfaction](/concepts/metric/user-satisfaction)  
+- [Conversation Relevancy](/concepts/metric/conversation-relevancy)  

--- a/concepts/metric/user-objective-accomplished.mdx
+++ b/concepts/metric/user-objective-accomplished.mdx
@@ -1,3 +1,4 @@
+---
 title: "User Objective Accomplished"
 description: "Evaluates whether the user's stated objective was successfully and correctly achieved during the conversation."
 ---

--- a/concepts/metric/user-satisfaction.mdx
+++ b/concepts/metric/user-satisfaction.mdx
@@ -1,0 +1,40 @@
+---
+title: "User Satisfaction"
+description: "Evaluates how satisfied the user was with the response of the model. It is a key indicator of user experience."
+---
+
+The **User Satisfaction** metric is one of several [non-deterministic Metrics](/concepts/metric) Galtea uses to evaluate the end-user's perception of a chatbot interaction. This metric focuses on the *experience* itself—whether the user left the conversation feeling content or frustrated. Even if a goal was technically achieved, poor interaction quality (such as inefficiency or negative sentiment) can lead to low satisfaction.
+
+This metric is particularly useful for monitoring the overall user experience, identifying friction points, and ensuring that chatbot responses not only solve problems but also foster trust and ease of use.
+
+---
+
+## Evaluation Parameters
+
+To compute the `user_satisfaction` metric, the following parameter is required:
+
+- **`conversation_turns`**: The complete history of user inputs and chatbot responses.
+
+The evaluation considers the *entire conversation* rather than individual responses in isolation.
+
+
+---
+
+## How Is It Calculated?
+
+The `user_satisfaction` score is derived using an LLM-as-a-judge approach with explicit pass criteria:
+
+1. **Efficiency Check**: Was the interaction smooth and direct, or did the user have to rephrase, repeat, or correct the chatbot?
+2. **Sentiment Analysis**: Did the user display positive/neutral sentiment or negative sentiment?
+
+Based on these criteria, the LLM assigns a **binary score**:
+
+- **1 (Satisfied):** The interaction was efficient and the user’s sentiment was neutral-to-positive.  
+- **0 (Not Satisfied):** The interaction was inefficient, the user expressed frustration, or both.
+
+---
+
+## Related Topics
+
+- [User Objective Accomplished](/concepts/metric/user-objective-accomplished)  
+- [Conversation Relevancy](/concepts/metric/conversation-relevancy)  

--- a/concepts/metric/user-satisfaction.mdx
+++ b/concepts/metric/user-satisfaction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "User Satisfaction"
-description: "Evaluates how satisfied the user was with the response of the model. It is a key indicator of user experience."
+description: "Evaluates how satisfied the user was with the conversation. It is a key indicator of user experience."
 ---
 
 The **User Satisfaction** metric is one of several [non-deterministic Metrics](/concepts/metric) Galtea uses to evaluate the end-user's perception of a chatbot interaction. This metric focuses on the *experience* itself—whether the user left the conversation feeling content or frustrated. Even if a goal was technically achieved, poor interaction quality (such as inefficiency or negative sentiment) can lead to low satisfaction.
@@ -16,7 +16,6 @@ To compute the `user_satisfaction` metric, the following parameter is required:
 - **`conversation_turns`**: The complete history of user inputs and chatbot responses.
 
 The evaluation considers the *entire conversation* rather than individual responses in isolation.
-
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -132,7 +132,7 @@
               {
                 "group": "Conversational",
                 "icon": "message",
-                "pages": ["concepts/metric/knowledge-retention", "concepts/metric/role-adherence", "concepts/metric/conversation-completeness", "concepts/metric/conversation-relevancy"]
+                "pages": ["concepts/metric/knowledge-retention", "concepts/metric/role-adherence", "concepts/metric/conversation-completeness", "concepts/metric/conversation-relevancy", "concepts/metric/user-satisfaction", "concepts/metric/user-objective-accomplished"]
               },
               {
                 "group": "Red Teaming",


### PR DESCRIPTION
Two new conversational metrics were added to the docs.

Closes this: 
Validated with E2E tests: 

<!-- Provide a clear summary of the changes made. -->

# Pull Request Checklist
- [ ] I have referenced the issue in the PR [description (or comments)](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I have requested a reviewer to this PR.
- [ ] I have added myself as the assignee.
- [ ] Added `hotfix` label if this PR is a critical fix that needs to be merged without approval.
