### PR TITLE
[Hotfix] Standardizes sort parameter name

### DIFF
--- a/sdk/api/evaluation/list.mdx
+++ b/sdk/api/evaluation/list.mdx
@@ -29,10 +29,10 @@ session_evaluations = galtea.evaluations.list(session_id="YOUR_SESSION_ID")
 <ResponseField name="metric_id" type="str | list[str]" default="None">
   The ID or IDs of the metric(s) for which you want to list evaluations.
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort evaluations by creation date. Valid values are "asc" and "desc".
 </ResponseField>
-<ResponseField name="sortByScore" type="string" optional>
+<ResponseField name="sort_by_score" type="string" optional>
   Sort evaluations by score. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int" optional>

--- a/sdk/api/inference-result/list.mdx
+++ b/sdk/api/inference-result/list.mdx
@@ -15,7 +15,7 @@ inference_results = galtea.inference_results.list(session_id="YOUR_SESSION_ID")
 <ResponseField name="session_id" type="string | list[string]" required>
   The ID or IDs of the session(s) to get inference results for.
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort inference results by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int" optional>

--- a/sdk/api/metric/list.mdx
+++ b/sdk/api/metric/list.mdx
@@ -12,7 +12,7 @@ metrics = galtea.metrics.list()
 ```
 
 ## Parameters
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort metrics by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int">

--- a/sdk/api/product/list.mdx
+++ b/sdk/api/product/list.mdx
@@ -12,7 +12,7 @@ products = galtea.products.list()
 ```
 
 ## Parameters
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort products by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int">

--- a/sdk/api/session/list.mdx
+++ b/sdk/api/session/list.mdx
@@ -25,7 +25,7 @@ sessions = galtea.sessions.list(version_id="YOUR_VERSION_ID")
 <ResponseField name="test_id" type="string | list[string]" optional>
   The ID or IDs of the test(s) to filter sessions by.
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort sessions by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <Note>

--- a/sdk/api/test-case/list.mdx
+++ b/sdk/api/test-case/list.mdx
@@ -36,7 +36,7 @@ paginated_test_cases = galtea.test_cases.list(test_id="YOUR_TEST_ID", offset=10,
 <ResponseField name="user_score" type="int" optional>
   Filter by user score (0 for unreviewed, 1 for good quality, -1 for bad quality).
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort test cases by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int" optional>

--- a/sdk/api/test/list.mdx
+++ b/sdk/api/test/list.mdx
@@ -15,7 +15,7 @@ tests = galtea.tests.list(product_id="YOUR_PRODUCT_ID")
 <ResponseField name="product_id" type="string | list[string]" required>
   The ID or IDs of the product(s) for which you want to list tests.
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort tests by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int">

--- a/sdk/api/version/list.mdx
+++ b/sdk/api/version/list.mdx
@@ -15,7 +15,7 @@ versions = galtea.versions.list(product_id="YOUR_PRODUCT_ID")
 <ResponseField name="product_id" type="string | list[string]" required>
   The ID or IDs of the product(s) for which you want to list versions.
 </ResponseField>
-<ResponseField name="sortByCreatedAt" type="string" optional>
+<ResponseField name="sort_by_created_at" type="string" optional>
   Sort versions by creation date. Valid values are "asc" and "desc".
 </ResponseField>
 <ResponseField name="offset" type="int">

--- a/sdk/usage.mdx
+++ b/sdk/usage.mdx
@@ -143,7 +143,7 @@ Once the [evaluations](/concepts/product/version/session/evaluation) are complet
 
 ```python
 # First, get all sessions for the version
-sessions = galtea.sessions.list(version_id=version.id, sortByCreatedAt="desc")
+sessions = galtea.sessions.list(version_id=version.id, sort_by_created_at="desc")
 
 # Iterate through all product sessions
 for session in sessions:


### PR DESCRIPTION
Renames the `sortByCreatedAt` parameter to `sort_by_created_at` for consistency across all list API endpoints.

Closes this: 
Validated with E2E tests: 

<!-- Provide a clear summary of the changes made. -->

# Pull Request Checklist
- [ ] I have referenced the issue in the PR [description (or comments)](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I have requested a reviewer to this PR.
- [ ] I have added myself as the assignee.
- [ ] Added `hotfix` label if this PR is a critical fix that needs to be merged without approval.
