### PR TITLE
How to create a custom prompt for evaluations and Product description update

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -85,7 +85,8 @@
               "sdk/tutorials/monitor-production-responses-to-user-queries",
               "sdk/tutorials/evaluating-conversations",
               "sdk/tutorials/simulating-conversations",
-              "sdk/tutorials/create-evaluation-with-custom-scores"
+              "sdk/tutorials/create-evaluation-with-custom-scores",
+              "sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -53,7 +53,7 @@
       "anchors": [
         {
           "anchor": "Blog",
-          "href": "https://galtea.ai/blog/index.html",
+          "href": "https://galtea.ai/blog",
           "icon": "newspaper"
         },
         {

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "All you need to get started with Galtea evaluations"
+description: "See how good your product really is with Galtea evaluations"
 icon: "rocket"
 ---
 
@@ -13,28 +13,35 @@ import EvaluationCard from '/snippets/cards/evaluation-card.mdx';
 import MetricCard from '/snippets/cards/metric-card.mdx';
 import ModelCard from '/snippets/cards/model-card.mdx';
 
-This guide will walk you through the steps to begin evaluating and monitoring the reliability of your AI products with Galtea as quickly as possible.
+So, you've built an amazing product – maybe an LLM, a RAG system, or another AI model – and you want to know just how good it truly is? That's exactly where the Galtea platform comes in! We're here to help you thoroughly test your product, uncover its strengths, and even spot those tricky edge cases you might not have considered.
+
+Let's walk through the steps you'll take to test your product with Galtea and understand why each part is so important.
 
 ## Evaluation Workflow Overview
 
 <Steps>
-  <Step title="Create a Product">Define what functionality or service you want to evaluate on the Galtea platform.</Step>
+  <Step title="Tell Us About Your Product">Provide details about your product so our models can create tailored testing content.</Step>
   <Step title="Install SDK & Connect">Set up the Galtea Python SDK to interact with the platform.</Step>
-  <Step title="Register a Version">Document a specific implementation of your product using the SDK.</Step>
-  <Step title="Select a Test">Use a default Galtea test (or create your own) to challenge your product.</Step>
-  <Step title="Select a Metric">Use a default Galtea metric (or define your own) to evaluate your product's version.</Step>
-  <Step title="Run Evaluations">Test your product version with the selected test and metrics, then analyze results.</Step>
+  <Step title="Version Your Product">Track different implementations to compare improvements over time.</Step>
+  <Step title="Create Your Tests">Build test datasets with input and ground truth pairs to challenge your product.</Step>
+  <Step title="Choose Your Metrics">Select from our metrics library or bring your own custom metrics.</Step>
+  <Step title="Run Evaluations">Test your product version with the selected test and metrics.</Step>
+  <Step title="See Your Results">Explore detailed insights and compare versions on the dashboard.</Step>
 </Steps>
 
-## 1. Create a Product
+## 1. Tell Us About Your Product
+
+To test your product effectively, our state-of-the-art LLMs and other models need to understand it inside and out. The more information you provide, the better equipped our models will be to create unique and highly specific testing content tailored just for your product.
 
 Create a [product](/concepts/product) in the Galtea dashboard. Navigate to **[Products](https://platform.galtea.ai/) > Create New Product** and complete the form.
 
 <Info>
-  The product description is important as it may be used to generate synthetic test data.
+  The product description is crucial – it powers our ability to generate synthetic test data that's specific to your use case.
 </Info>
 
-## 2. Install the SDK and Connect
+## 2. Get Started with the SDK
+
+Just like with many other AI tools, you have options! You can do everything through our intuitive dashboard GUI, or you can get programmatic with our Python SDK. For this quickstart, we'll focus on using the Python SDK.
 
 <Steps>
   <Step title="Get your API key">
@@ -59,7 +66,11 @@ Create a [product](/concepts/product) in the Galtea dashboard. Navigate to **[Pr
   </Step>
 </Steps>
 
-## 3. Create a Version
+## 3. Version Your Product
+
+Imagine this: Galtea shows you that your product doesn't perform perfectly on certain edge cases you hadn't anticipated. Naturally, you go back, make some tweaks, and now you have a new, improved version! You test your new version again on Galtea. But how do you compare if the new model is better than the previous one?
+
+Galtea provides a robust way to version your product – attach a version name, ID, and metadata to each of your product/model versions. This means you can easily compare the results of different versions, filter your findings, and clearly see if your new version is, in fact, an improvement over the old one.
 
 Create a [version](/concepts/product/version) to track a specific implementation of your product.
 
@@ -72,9 +83,18 @@ version = galtea.versions.create(
 print(f"Created Version with ID: {version.id}")
 ```
 
-## 4. Use a Default Test
+## 4. Create Your Tests
 
-For this quickstart, we'll use the default "Jailbreak" [test](/concepts/product/test), which is a type of [Red Teaming Test](/concepts/product/test/red-teaming-tests).
+This is where we build the core of your evaluation: the test dataset. This dataset consists of input and ground truth pairs. We'll feed the input to your product/model, and then compare its prediction against the ground truth to see how well it performed.
+
+We offer two main ways to generate this crucial test data:
+
+1. **Using Your Product Description:** If, for example, your product is a RAG system designed for financial data, we'll automatically generate a test dataset that a RAG system for financial data should excel at.
+2. **Using Your Specific Data:** Do you have very particular PDFs or text files that your product absolutely *must* handle correctly? No problem! You can upload these files, and we'll generate a test dataset directly from them, ensuring your product is tested on your critical content.
+
+In Galtea, this entire test dataset is simply called a "[test](/concepts/product/test)," and each individual row within it is a "[test case](/concepts/product/test/case)."
+
+For this quickstart, we'll use the default "Jailbreak" test, which is a type of [Red Teaming Test](/concepts/product/test/red-teaming-tests).
 
 ```python
 test = galtea.tests.get_by_name(product_id=YOUR_PRODUCT_ID, test_name="Jailbreak")
@@ -82,15 +102,21 @@ test_cases = galtea.test_cases.list(test_id=test.id)
 print(f"Using test '{test.name}' with {len(test_cases)} test cases.")
 ```
 
-## 5. Use a Default Metric
+## 5. Choose Your Metrics
 
-To evaluate the "Jailbreak" test, we'll use the "Jailbreak Resilience" [metric](concepts/metric/jailbreak-resilience).
+Anyone familiar with machine learning knows that after comparing predictions to ground truth, you get a "loss," but you also need a meaningful metric to interpret that loss. This step is all about selecting the right metrics for your evaluation.
+
+You can bring your own custom metrics to the table, or you can choose from our wide array of available [metrics](/concepts/metric) (like QA, text-specific metrics, IOU, and many more).
+
+To evaluate the "Jailbreak" test, we'll use the "[Jailbreak Resilience](/concepts/metric/jailbreak-resilience)" metric.
 
 ```python
 metric = galtea.metrics.get_by_name(name="Jailbreak Resilience")
 ```
 
-## 6. Run Evaluations
+## 6. Run the Evaluation
+
+This step is exactly what it sounds like! We take each test case from your created tests, pass its input through your product/model, compare the prediction to the ground truth, and calculate the metric values. You'll get detailed metric values for every single test case within your tests.
 
 Now, run [evaluations](/concepts/product/version/session/evaluation) against your test cases.
 
@@ -120,9 +146,13 @@ for test_case in test_cases:
 print(f"Submitted evaluations for version {version.id} using test '{test.name}'.")
 ```
 
-## 7. View Results
+## 7. See Your Results
 
-You can view results on the [Galtea dashboard](https://platform.galtea.ai/). Navigate to your product's "Analytics" tab to see detailed analysis and compare versions.
+Once you've run evaluations across all your tests and thoroughly tested your product/model, it's time to dive into the insights! You can view all your results on the [Galtea platform](https://platform.galtea.ai/) in a highly intuitive way.
+
+Our dashboard allows you to filter and explore your data however you like – by versions, metrics, specific tests, and more. You can see aggregate scores for an overall picture or drill down into the results of individual test cases.
+
+Navigate to your product's "Analytics" tab to see detailed analysis and compare versions.
 
 ```python
 print(f"View results at: https://platform.galtea.ai/product/{YOUR_PRODUCT_ID}?tab=1")

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -116,7 +116,7 @@ metric = galtea.metrics.get_by_name(name="Jailbreak Resilience")
 
 ## 6. Run the Evaluation
 
-This step is exactly what it sounds like! We take each test case from your created tests, pass its input through your product/model, compare the prediction to the ground truth, and calculate the metric values. You'll get detailed metric values for every single test case within your tests.
+This step is exactly what it sounds like! We take each test case from your created tests, pass its input through your product/model, compare the output to the ground truth, and calculate the metric values. You'll get detailed metric values for every single test case within your tests.
 
 Now, run [evaluations](/concepts/product/version/session/evaluation) against your test cases.
 

--- a/sdk/tutorials/create-test.mdx
+++ b/sdk/tutorials/create-test.mdx
@@ -61,10 +61,10 @@ The Galtea SDK provides methods to create both [Quality Tests](/concepts/product
 
     # Generate a test from a PDF knowledge base
     test = galtea.tests.create(
-        name="legal-document-test-from-pdf",
+        name="financial-qa-test",
         type="QUALITY",
         product_id="YOUR_PRODUCT_ID",
-        ground_truth_file_path="path/to/your/legal_document.pdf",
+        ground_truth_file_path="path/to/your/financial_document.pdf",
         language="english",
         max_test_cases=50 # Limit the number of generated test cases
     )

--- a/sdk/tutorials/evaluating-conversations.mdx
+++ b/sdk/tutorials/evaluating-conversations.mdx
@@ -96,9 +96,9 @@ session = galtea.sessions.create(
 )
 
 conversation_turns = [
-    {"role": "user", "content": "What are some less risk investment strategies?"},
+    {"role": "user", "content": "What are some lower-risk investment strategies?"},
     {"role": "assistant", "content": "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities.", "retrieval_context": "Low-risk investment options include index funds, government bonds, and Treasury securities."},
-    {"role": "user", "content": "With age, should the investment strategy change??"},
+    {"role": "user", "content": "With age, should the investment strategy change?"},
     {"role": "assistant", "content": "Yes, many advisors recommend shifting to more conservative investments as you approach retirement.", "retrieval_context": "Financial advisors typically recommend a more conservative asset allocation as investors near retirement age."},
 ]
 
@@ -146,7 +146,7 @@ def handle_turn(user_input: str) -> str:
   <Tab title="Log turns in a batch">
 ```python
 conversation_turns = [
-    {"role": "user", "content": "What are some less risk investment strategies?"},
+    {"role": "user", "content": "What are some lower-risk investment strategies?"},
     {"role": "assistant", "content": "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities."},
 ]
 

--- a/sdk/tutorials/evaluating-conversations.mdx
+++ b/sdk/tutorials/evaluating-conversations.mdx
@@ -98,7 +98,7 @@ session = galtea.sessions.create(
 conversation_turns = [
     {"role": "user", "content": "What are some less risk investment strategies?"},
     {"role": "assistant", "content": "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities.", "retrieval_context": "Low-risk investment options include index funds, government bonds, and Treasury securities."},
-    {"role": "user", "content": "With age, should the invetment stratagy change??"},
+    {"role": "user", "content": "With age, should the investment strategy change??"},
     {"role": "assistant", "content": "Yes, many advisors recommend shifting to more conservative investments as you approach retirement.", "retrieval_context": "Financial advisors typically recommend a more conservative asset allocation as investors near retirement age."},
 ]
 

--- a/sdk/tutorials/evaluating-conversations.mdx
+++ b/sdk/tutorials/evaluating-conversations.mdx
@@ -96,10 +96,10 @@ session = galtea.sessions.create(
 )
 
 conversation_turns = [
-    {"role": "user", "content": "Hello, what can you do?"},
-    {"role": "assistant", "content": "I can help with your queries.", "retrieval_context": None},
-    {"role": "user", "content": "What's your return policy?"},
-    {"role": "assistant", "content": "Returns within 30 days.", "retrieval_context": "Returns are accepted within 30 days of purchase."},
+    {"role": "user", "content": "What are some less risk investment strategies?"},
+    {"role": "assistant", "content": "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities.", "retrieval_context": "Low-risk investment options include index funds, government bonds, and Treasury securities."},
+    {"role": "user", "content": "With age, should the invetment stratagy change??"},
+    {"role": "assistant", "content": "Yes, many advisors recommend shifting to more conservative investments as you approach retirement.", "retrieval_context": "Financial advisors typically recommend a more conservative asset allocation as investors near retirement age."},
 ]
 
 # Log all turns at once
@@ -146,8 +146,8 @@ def handle_turn(user_input: str) -> str:
   <Tab title="Log turns in a batch">
 ```python
 conversation_turns = [
-    {"role": "user", "content": "What's the weather like in Paris?"},
-    {"role": "assistant", "content": "It's sunny and 22°C in Paris."},
+    {"role": "user", "content": "What are some less risk investment strategies?"},
+    {"role": "assistant", "content": "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities."},
 ]
 
 galtea.inference_results.create_batch(

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -74,8 +74,8 @@ For each [unit of analysis], verify:
 
 **Scoring Rubric:**
 
-- **Score [X]:** [Clear threshold with specific conditions]
-- **Score [Y]:** [Clear threshold with specific failure modes/edge cases]
+- **Score 1:** [Clear threshold for success, e.g., "All evaluation criteria are met."]
+- **Score 0:** [Clear threshold for failure, e.g., "One or more evaluation criteria are not met."]
 ```
 
 <Note>
@@ -117,8 +117,8 @@ metric = galtea.metrics.create(
 
     **Scoring Rubric:**
 
-    - **Score [X]:** [Clear threshold with specific conditions]
-    - **Score [Y]:** [Clear threshold with specific failure modes/edge cases]
+    - **Score 1:** [Clear threshold for success, e.g., "All evaluation criteria are met."]
+    - **Score 0:** [Clear threshold for failure, e.g., "One or more evaluation criteria are not met."]
     """,
     evaluator_model_name="GPT-4o",
     evaluation_params=["input", "actual_output"],

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -64,8 +64,6 @@ For each [unit of analysis]:
 ```
 **Role:** You are evaluating [what aspect] of [what system/output].
 
-**Task:** Analyze [data source] to assess [specific goal].
-
 **Evaluation Criteria:**
 
 For each [unit of analysis], verify:
@@ -80,4 +78,51 @@ For each [unit of analysis], verify:
 - **Score [Y]:** [Clear threshold with specific failure modes/edge cases]
 ```
 
+<Note>
+  This template serves as a starting skeleton that you can adapt and modify based on your specific evaluation needs. Feel free to add more criteria, adjust the scoring scale, or restructure sections to better fit your use case.
+</Note>
+
 The key is: **If you can't program it as a rule-based system, your criteria aren't specific enough for an LLM judge either.**
+
+## How to implement it with Galtea?
+
+Here's an example of how to create a custom metric using the template above:
+
+```python
+
+from datetime import datetime
+from galtea import Galtea
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+galtea = Galtea(api_key=os.getenv("API_KEY"))
+
+# Create a new metric
+metric = galtea.metrics.create(
+    name="Generic Metric",
+    test_type="QUALITY",  # or "RED_TEAMING", "SCENARIO"
+    source="partial_prompt",
+    judge_prompt="""
+    **Role:** You are evaluating [what aspect] of [what system/output].
+
+    **Evaluation Criteria:**
+
+    For each [unit of analysis], verify:
+
+    1. **[Criterion name]:** [Specific, measurable condition with examples]
+    2. **[Criterion name]:** [Specific, measurable condition with examples]
+    3. **[Criterion name]:** [Specific, measurable condition with examples]
+
+    **Scoring Rubric:**
+
+    - **Score [X]:** [Clear threshold with specific conditions]
+    - **Score [Y]:** [Clear threshold with specific failure modes/edge cases]
+    """,
+    evaluator_model_name="GPT-4o",
+    evaluation_params=["input", "actual_output"],
+    description="Genertic Metric",
+    tags=["quality"],
+)
+``` 

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -8,17 +8,26 @@ You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evalu
 
 ## Key Components of a Judge Prompt
 
-### 1. **Role (Context)**
-- Clearly state what the evaluator is assessing
+### 1. **Role (Optional)**
 
-### 2. **Evaluation Criteria (The "What")**
+Clearly state what the evaluator is assessing:
 
-**Best Practices:**
-- **Be specific and measurable:** Avoid vague terms like "good quality" - define what quality means
-- **Break down into discrete checks:** Each criterion should evaluate one distinct aspect
-- **Use objective indicators:** Focus on observable behaviors rather than subjective judgments
-- **Provide examples:** Include what to look for (positive) and what to avoid (negative)
-- **Number your criteria:** Makes them easier to reference and ensures completeness
+```
+**Role:** You are evaluating the _accuracy_ of the _ACTUAL_OUTPUT_.
+
+### 2. **Evaluation Criteria (Essential)**
+
+
+**What are Evaluation Criteria?**
+
+Evaluation criteria are the clear rules or checkpoints you want the judge (LLM or human) to use when reviewing an output. They help make your evaluation process fair, repeatable, and easy to understand.
+
+**Recommendations:**
+- **Be specific:** Do not use vague terms like "good quality." Instead, explain exactly what quality means for your use case.
+- **Break it down (itemization):** Breaking down your criteria into separate, clearly defined points makes them easier to check, score, and understand. Each criterion should focus on one thing at a time.
+- **Use objective signals:** Look for things you can see or measure, not just opinions or feelings.
+- **Give examples:** Show what a good answer looks like, and what a bad answer looks like, for each criterion.
+- **Number your criteria:** This makes them easier to reference and ensures you don't miss anything important.
 
 **Structure:**
 ```
@@ -28,27 +37,22 @@ For each [unit of analysis]:
 3. Ensure that [specific condition C]
 ```
 
-### 3. **Scoring Rubric (The "How to Score")**
+### 3. **Scoring Rubric (Essential)**
 
-**Key Principles:**
+The scoring rubric is how you decide what score to give for each output. It sets the rules for what counts as a pass or fail, and helps make your evaluation fair and consistent. Here are the main things to keep in mind:
 
-**A. Define clear thresholds:**
-- Binary (0/1): Specify exactly what constitutes pass vs. fail
+**A. Define clear thresholds.** Binary (0/1): Specify exactly what counts as a pass or a fail. Make your scoring rules easy to understand and apply.
 
 **B. Use consistent logic:**
-- **All-or-nothing:** "ALL criteria must be met" vs "AT LEAST ONE failure"
-- **Counting-based:** "Score based on number of criteria satisfied"
-- **Severity-based:** "Critical failures = 0, minor issues = partial credit"
+- **All-or-nothing (recommended for direct validation of your system):** Decide whether all criteria must be met for a passing score, or if a single failure results in a fail.
+- **Counting-based:** You can also score based on how many criteria are satisfied.
 
-**C. Cover edge cases:**
-- What if criteria conflict?
-- What if data is missing or ambiguous?
-- Explicit handling of boundary conditions
+**C. Cover edge cases:** Think about what happens if criteria conflict, if data is missing, or if something is unclear. Make sure your rubric explains how to handle these situations.
 
 **Structure for Binary:**
 ```
-- Score 1: [Positive condition - what success looks like]
-- Score 0: [Negative condition - specific failure modes]
+- Score 1: The ACTUAL_OUTPUT meets all the evaluation criteria you listed above. For example, it is accurate, complete, and follows all instructions.
+- Score 0: The ACTUAL_OUTPUT fails one or more of the evaluation criteria. For example, it is missing key information, contains errors, or does not follow a specific instructions.
 ```
 
 ## Common Pitfalls to Avoid
@@ -62,7 +66,7 @@ For each [unit of analysis]:
 ## Template
 
 ```
-**Role:** You are evaluating [what aspect] of [what system/output].
+**Role:** You are evaluating [aspect] of [parameter].
 
 **Evaluation Criteria:**
 

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -43,9 +43,7 @@ The scoring rubric is how you decide what score to give for each output. It sets
 
 **A. Define clear thresholds.** Binary (0/1): Specify exactly what counts as a pass or a fail. Make your scoring rules easy to understand and apply.
 
-**B. Use consistent logic:**
-- **All-or-nothing (recommended for direct validation of your system):** Decide whether all criteria must be met for a passing score, or if a single failure results in a fail.
-- **Counting-based:** You can also score based on how many criteria are satisfied.
+**B. All-or-nothing logic (recommended for direct system validation):** Assign a passing score only when *every* instruction or criterion is fully satisfied. In other words, if all requirements are met, score 1; if any requirement is not met, score 0.
 
 **C. Cover edge cases:** Think about what happens if criteria conflict, if data is missing, or if something is unclear. Make sure your rubric explains how to handle these situations.
 

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'How to create your LLM-as-a-judge prompt?'
-description: "A comprehensive framework for constructing LLM-as-a-judge prompts through the specification of objective evaluation criteria and the definition of unambiguous scoring rubrics with precise thresholds."
+title: 'How to create your judge prompt?'
+description: "A practical guide for writing LLM-as-a-judge prompts: define objective evaluation criteria, unambiguous scoring rubrics, and machine-friendly outputs."
 icon: "pen"
 ---
 
-You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with a high degree of flexibility. However, this raises an important question: how do you translate the idea you want to evaluate into an effective, usable prompt?
+You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with full flexibility. However, this can be highly complex or even impossible in some cases. In this guide we will explain how to translate the idea you want to evaluate into an effective, usable prompt so an LLM can do the judging.
 
 ## Key Components of a Judge Prompt
 
@@ -12,24 +12,23 @@ You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evalu
 
 Clearly state what the evaluator is assessing:
 
+*Example Structure:*
 ```
-**Role:** You are evaluating the _accuracy_ of the _ACTUAL_OUTPUT_.
+**Role:** You are evaluating the _thing to evaluate_ of the _ACTUAL_OUTPUT_.
+```
 
 ### 2. **Evaluation Criteria (Essential)**
 
-
-**What are Evaluation Criteria?**
-
-Evaluation criteria are the clear rules or checkpoints you want the judge (LLM or human) to use when reviewing an output. They help make your evaluation process fair, repeatable, and easy to understand.
+Evaluation criteria are the clear rules or checkpoints you want the judge to use when reviewing an output. They help make your evaluation process fair, repeatable, and easy to understand.
 
 **Recommendations:**
 - **Be specific:** Do not use vague terms like "good quality." Instead, explain exactly what quality means for your use case.
-- **Break it down (itemization):** Breaking down your criteria into separate, clearly defined points makes them easier to check, score, and understand. Each criterion should focus on one thing at a time.
+- **Break it down (itemization):** Break down your criteria into separate, clearly defined points. Make them easier to check, score, and understand. Each criterion should focus on one thing at a time.
 - **Use objective signals:** Look for things you can see or measure, not just opinions or feelings.
 - **Give examples:** Show what a good answer looks like, and what a bad answer looks like, for each criterion.
-- **Number your criteria:** This makes them easier to reference and ensures you don't miss anything important.
+- **Number your criteria:** This makes them easier to reference and ensures anything important is missed.
 
-**Structure:**
+*Example Structure:*
 ```
 For each [unit of analysis]:
 1. Check that [specific condition A]
@@ -39,19 +38,25 @@ For each [unit of analysis]:
 
 ### 3. **Scoring Rubric (Essential)**
 
-The scoring rubric is how you decide what score to give for each output. It sets the rules for what counts as a pass or fail, and helps make your evaluation fair and consistent. Here are the main things to keep in mind:
+The scoring rubric is how you decide what score to give for each output. It sets the rules for what counts as a pass or fail, and helps make your evaluation fair and consistent.
 
-**A. Define clear thresholds.** Binary (0/1): Specify exactly what counts as a pass or a fail. Make your scoring rules easy to understand and apply.
+Here are the main things to keep in mind:
 
-**B. All-or-nothing logic (recommended for direct system validation):** Assign a passing score only when *every* instruction or criterion is fully satisfied. In other words, if all requirements are met, score 1; if any requirement is not met, score 0.
+**A. Define clear thresholds.** Make your scoring rules easy to understand and apply. For example, if using binary scoring (either a 0 or a 1), specify exactly what counts as a pass or a fail.
 
-**C. Cover edge cases:** Think about what happens if criteria conflict, if data is missing, or if something is unclear. Make sure your rubric explains how to handle these situations.
+**B. Cover edge cases:** Think about what happens if criteria conflict, if data is missing, or if something is unclear. Make sure your rubric explains how to handle these situations.
 
-**Structure for Binary:**
+<Info>
+**All-or-nothing logic**: recommended for direct system validation. Use this when you want a strict pass/fail: score 1 only when *every* requirement is satisfied; otherwise score 0.
+</Info>
+
+*Example Structure for Binary:*
 ```
 - Score 1: The ACTUAL_OUTPUT meets all the evaluation criteria you listed above. For example, it is accurate, complete, and follows all instructions.
 - Score 0: The ACTUAL_OUTPUT fails one or more of the evaluation criteria. For example, it is missing key information, contains errors, or does not follow a specific instructions.
 ```
+
+You can also use graded rubrics (for example, 0-2 or 0-5). When using graded rubrics, define each numeric level explicitly and include a short example for each level so the judge behaves consistently.
 
 ## Common Pitfalls to Avoid
 
@@ -60,6 +65,10 @@ The scoring rubric is how you decide what score to give for each output. It sets
 3. **Missing edge cases:** Not specifying what happens with partial matches or ambiguous data
 4. **Subjective language:** "Natural" or "appropriate" without defining what that means
 5. **Overlapping criteria:** Multiple criteria testing the same thing differently
+
+<Note>
+  The key is: If you can't program it as a rule-based system, your criteria aren't specific enough for an LLM judge either.
+</Note>
 
 ## Template
 
@@ -84,11 +93,11 @@ For each [unit of analysis], verify:
   This template serves as a starting skeleton that you can adapt and modify based on your specific evaluation needs. Feel free to add more criteria, adjust the scoring scale, or restructure sections to better fit your use case.
 </Note>
 
-The key is: **If you can't program it as a rule-based system, your criteria aren't specific enough for an LLM judge either.**
-
 ## How to implement it with Galtea?
 
-Here's an example of how to create a custom metric using the template above:
+You can create your custom metric in Galtea using the [Dashboard ](https://platform.galtea.ai/metric-new) or the SDK.
+
+Here's an example of how to create a custom metric using the SDK with the template shown above:
 
 ```python
 
@@ -107,7 +116,7 @@ metric = galtea.metrics.create(
     test_type="QUALITY",  # or "RED_TEAMING", "SCENARIO"
     source="partial_prompt",
     judge_prompt="""
-    **Role:** You are evaluating [what aspect] of [what system/output].
+    **Role:** You are evaluating the [aspect] of the ACTUAL_OUTPUT.
 
     **Evaluation Criteria:**
 
@@ -124,7 +133,7 @@ metric = galtea.metrics.create(
     """,
     evaluator_model_name="GPT-4o",
     evaluation_params=["input", "actual_output"],
-    description="Genertic Metric",
+    description="Generic Metric",
     tags=["quality"],
 )
 ``` 

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -1,0 +1,83 @@
+---
+title: 'How to create your LLM-as-a-judge prompt?'
+description: "A comprehensive framework for constructing LLM-as-a-judge prompts through the specification of objective evaluation criteria and the definition of unambiguous scoring rubrics with precise thresholds."
+icon: "comments"
+---
+
+You can use galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with a high degree of flexibility. However, this raises an important question: how do you translate the idea you want to evaluate into an effective, usable prompt?
+
+## Key Components of a Judge Prompt
+
+### 1. **Role (Context)**
+- Clearly state what the evaluator is assessing
+
+### 2. **Evaluation Criteria (The "What")**
+
+**Best Practices:**
+- **Be specific and measurable:** Avoid vague terms like "good quality" - define what quality means
+- **Break down into discrete checks:** Each criterion should evaluate one distinct aspect
+- **Use objective indicators:** Focus on observable behaviors rather than subjective judgments
+- **Provide examples:** Include what to look for (positive) and what to avoid (negative)
+- **Number your criteria:** Makes them easier to reference and ensures completeness
+
+**Structure:**
+```
+For each [unit of analysis]:
+1. Check that [specific condition A]
+2. Verify that [specific condition B]
+3. Ensure that [specific condition C]
+```
+
+### 3. **Scoring Rubric (The "How to Score")**
+
+**Key Principles:**
+
+**A. Define clear thresholds:**
+- Binary (0/1): Specify exactly what constitutes pass vs. fail
+
+**B. Use consistent logic:**
+- **All-or-nothing:** "ALL criteria must be met" vs "AT LEAST ONE failure"
+- **Counting-based:** "Score based on number of criteria satisfied"
+- **Severity-based:** "Critical failures = 0, minor issues = partial credit"
+
+**C. Cover edge cases:**
+- What if criteria conflict?
+- What if data is missing or ambiguous?
+- Explicit handling of boundary conditions
+
+**Structure for Binary:**
+```
+- Score 1: [Positive condition - what success looks like]
+- Score 0: [Negative condition - specific failure modes]
+```
+
+## Common Pitfalls to Avoid
+
+1. **Vague criteria:** "Check if response is good" → Instead: "Check if response addresses all parts of the user's question"
+2. **Ambiguous thresholds:** "Mostly correct" → Instead: "At least 3 out of 4 criteria met"
+3. **Missing edge cases:** Not specifying what happens with partial matches or ambiguous data
+4. **Subjective language:** "Natural" or "appropriate" without defining what that means
+5. **Overlapping criteria:** Multiple criteria testing the same thing differently
+
+## Template
+
+```
+**Role:** You are evaluating [what aspect] of [what system/output].
+
+**Task:** Analyze [data source] to assess [specific goal].
+
+**Evaluation Criteria:**
+
+For each [unit of analysis], verify:
+
+1. **[Criterion name]:** [Specific, measurable condition with examples]
+2. **[Criterion name]:** [Specific, measurable condition with examples]
+3. **[Criterion name]:** [Specific, measurable condition with examples]
+
+**Scoring Rubric:**
+
+- **Score [X]:** [Clear threshold with specific conditions]
+- **Score [Y]:** [Clear threshold with specific failure modes/edge cases]
+```
+
+The key is: **If you can't program it as a rule-based system, your criteria aren't specific enough for an LLM judge either.**

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'How to create your judge prompt?'
 description: "A practical guide for writing LLM-as-a-judge prompts: define objective evaluation criteria, unambiguous scoring rubrics, and machine-friendly outputs."
-icon: "pen"
+icon: "gavel"
+iconType: "solid"
 ---
 
 You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with full flexibility. However, this can be highly complex or even impossible in some cases. In this guide we will explain how to translate the idea you want to evaluate into an effective, usable prompt so an LLM can do the judging.
@@ -26,7 +27,7 @@ Evaluation criteria are the clear rules or checkpoints you want the judge to use
 - **Break it down (itemization):** Break down your criteria into separate, clearly defined points. Make them easier to check, score, and understand. Each criterion should focus on one thing at a time.
 - **Use objective signals:** Look for things you can see or measure, not just opinions or feelings.
 - **Give examples:** Show what a good answer looks like, and what a bad answer looks like, for each criterion.
-- **Number your criteria:** This makes them easier to reference and ensures anything important is missed.
+- **Number your criteria:** This makes them easier to reference and ensures nothing important is missed.
 
 *Example Structure:*
 ```

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -4,7 +4,7 @@ description: "A comprehensive framework for constructing LLM-as-a-judge prompts 
 icon: "pen"
 ---
 
-You can use galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with a high degree of flexibility. However, this raises an important question: how do you translate the idea you want to evaluate into an effective, usable prompt?
+You can use Galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with a high degree of flexibility. However, this raises an important question: how do you translate the idea you want to evaluate into an effective, usable prompt?
 
 ## Key Components of a Judge Prompt
 

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -53,7 +53,7 @@ Here are the main things to keep in mind:
 *Example Structure for Binary:*
 ```
 - Score 1: The ACTUAL_OUTPUT meets all the evaluation criteria you listed above. For example, it is accurate, complete, and follows all instructions.
-- Score 0: The ACTUAL_OUTPUT fails one or more of the evaluation criteria. For example, it is missing key information, contains errors, or does not follow a specific instructions.
+- Score 0: The ACTUAL_OUTPUT fails one or more of the evaluation criteria. For example, it is missing key information, contains errors, or does not follow specific instructions.
 ```
 
 You can also use graded rubrics (for example, 0-2 or 0-5). When using graded rubrics, define each numeric level explicitly and include a short example for each level so the judge behaves consistently.
@@ -100,15 +100,13 @@ You can create your custom metric in Galtea using the [Dashboard ](https://platf
 Here's an example of how to create a custom metric using the SDK with the template shown above:
 
 ```python
-
-from datetime import datetime
 from galtea import Galtea
 from dotenv import load_dotenv
 import os
 
 load_dotenv()
 
-galtea = Galtea(api_key=os.getenv("API_KEY"))
+galtea = Galtea(api_key=os.getenv("GALTEA_API_KEY"))
 
 # Create a new metric
 metric = galtea.metrics.create(

--- a/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
+++ b/sdk/tutorials/how-to-create-your-llm-as-a-judge-prompt.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'How to create your LLM-as-a-judge prompt?'
 description: "A comprehensive framework for constructing LLM-as-a-judge prompts through the specification of objective evaluation criteria and the definition of unambiguous scoring rubrics with precise thresholds."
-icon: "comments"
+icon: "pen"
 ---
 
 You can use galtea to [Evaluate with Custom Metrics](/sdk/tutorials/create-evaluation-with-custom-scores) and tailor your evaluation with a high degree of flexibility. However, this raises an important question: how do you translate the idea you want to evaluate into an effective, usable prompt?

--- a/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
@@ -51,10 +51,7 @@ galtea = Galtea(api_key=os.getenv("GALTEA_API_KEY"))
 VERSION_ID = "YOUR_ACTIVE_VERSION_ID"
 METRICS_TO_EVALUATE = [
     "Conversation Relevancy",
-    "Knowledge Retention
-
-
-"
+    "Knowledge Retention"
 ]
 
 # Use is_production=True for real user interactions
@@ -81,8 +78,8 @@ def get_model_response(user_input):
 
 # This would happen dynamically in your application.
 user_questions = [
-    "What's the weather like in Paris?",
-    "Is it expected to rain later?",
+    "What are some less risk investment strategies?",
+    "With age, should the invetment stratagy change??",
     "Great, thanks!"
 ]
 
@@ -103,10 +100,10 @@ If you have the entire conversation history, you can log all turns at once for e
 ```python
 # The conversation must be in the standard format: a list of role/content dictionaries
 conversation_turns = [
-    {'role': 'user', 'content': "What's the weather like in Paris?"},
-    {'role': 'assistant', 'content': "It's sunny and 22°C in Paris."},
-    {'role': 'user', 'content': "Is it expected to rain later?"},
-    {'role': 'assistant', 'content': "No, the forecast shows clear skies for the rest of the day."},
+    {'role': 'user', 'content': "What are some less risk investment strategies?"},
+    {'role': 'assistant', 'content': "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities."},
+    {'role': 'user', 'content': "With age, should the invetment stratagy change??"},
+    {'role': 'assistant', 'content': "Yes, many advisors recommend shifting to more conservative investments as you approach retirement."},
     {'role': 'user', 'content': "Great, thanks!"},
     {'role': 'assistant', 'content': "You're welcome!"}
 ]

--- a/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
+++ b/sdk/tutorials/monitor-production-responses-to-user-queries.mdx
@@ -78,8 +78,8 @@ def get_model_response(user_input):
 
 # This would happen dynamically in your application.
 user_questions = [
-    "What are some less risk investment strategies?",
-    "With age, should the invetment stratagy change??",
+    "What are some lower-risk investment strategies?",
+    "With age, should the investment strategy change?",
     "Great, thanks!"
 ]
 
@@ -100,9 +100,9 @@ If you have the entire conversation history, you can log all turns at once for e
 ```python
 # The conversation must be in the standard format: a list of role/content dictionaries
 conversation_turns = [
-    {'role': 'user', 'content': "What are some less risk investment strategies?"},
+    {'role': 'user', 'content': "What are some lower-risk investment strategies?"},
     {'role': 'assistant', 'content': "For lower-risk investments, consider diversified index funds, bonds, or Treasury securities."},
-    {'role': 'user', 'content': "With age, should the invetment stratagy change??"},
+    {'role': 'user', 'content': "With age, should the investment strategy change?"},
     {'role': 'assistant', 'content': "Yes, many advisors recommend shifting to more conservative investments as you approach retirement."},
     {'role': 'user', 'content': "Great, thanks!"},
     {'role': 'assistant', 'content': "You're welcome!"}

--- a/sdk/tutorials/simulating-conversations.mdx
+++ b/sdk/tutorials/simulating-conversations.mdx
@@ -63,7 +63,7 @@ In order to run simulations of conversations we need to have different scenarios
 galtea_client = galtea.Galtea(api_key="YOUR_API_KEY")
 
 # Call the product and version you want to evaluate
-product = galtea_client.products.get_by_name("Vegetarian recipe agent")
+product = galtea_client.products.get_by_name("Financial advisor agent")
 version_name = "v1.0"
 try:
     # Get the version if it exists


### PR DESCRIPTION
This pull request updates documentation and tutorials to improve clarity, add new guidance, and align examples with financial use cases. The most important changes are grouped below.

**Quickstart and Documentation Improvements:**

* The `quickstart.mdx` guide has been rewritten for clarity, with a more user-friendly tone, clearer step descriptions, and enhanced explanations for each workflow stage. Steps and section titles have been renamed and expanded to better guide new users through the evaluation process. [[1]](diffhunk://#diff-3c10419c1599dbac4204b3ed274e3d2e9d25d6dffa3b3720fba7abcc52a6a66fL3-R3) [[2]](diffhunk://#diff-3c10419c1599dbac4204b3ed274e3d2e9d25d6dffa3b3720fba7abcc52a6a66fL16-R44) [[3]](diffhunk://#diff-3c10419c1599dbac4204b3ed274e3d2e9d25d6dffa3b3720fba7abcc52a6a66fL62-R73) [[4]](diffhunk://#diff-3c10419c1599dbac4204b3ed274e3d2e9d25d6dffa3b3720fba7abcc52a6a66fL75-R119) [[5]](diffhunk://#diff-3c10419c1599dbac4204b3ed274e3d2e9d25d6dffa3b3720fba7abcc52a6a66fL123-R155)
* The blog anchor in `docs.json` was updated to a cleaner URL, and a new tutorial link for creating LLM judge prompts was added to the sidebar. [[1]](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eL56-R56) [[2]](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eL88-R89)

**New Tutorials and Expanded Guidance:**

* Added a new tutorial `how-to-create-your-llm-as-a-judge-prompt.mdx` explaining how to design objective, machine-friendly evaluation prompts for LLM-as-a-judge metrics, including a template and practical tips.

**Tutorial Example Updates (Financial Use Cases):**

* Multiple tutorial examples were updated to use financial domain scenarios instead of weather or recipe examples. This includes changes in conversation logging, test creation, and simulated agent examples to better reflect financial product evaluation. [[1]](diffhunk://#diff-8c289c35ea3280db5c63bf1bd1a0c5e2719c38fb9ff8d187a86a03bc86ce4602L64-R67) [[2]](diffhunk://#diff-48fa7dcf14293d39ca96e1ebc2224a7cd6acc29cd038d7480d753957601f557bL99-R102) [[3]](diffhunk://#diff-48fa7dcf14293d39ca96e1ebc2224a7cd6acc29cd038d7480d753957601f557bL149-R150) [[4]](diffhunk://#diff-8fbda5718a70c640c63f9bb2e1b8757d8ddc718ea03d7c7acd7de5bab7dd0cc5L84-R82) [[5]](diffhunk://#diff-8fbda5718a70c640c63f9bb2e1b8757d8ddc718ea03d7c7acd7de5bab7dd0cc5L106-R106) [[6]](diffhunk://#diff-904aa12541f104a0833a3fbaf2bc3b4a575abc5c52bcc8d7df5e29d67839bd74L66-R66)

**Minor Fixes:**

* Fixed a stray newline and formatting issue in the metrics list in `monitor-production-responses-to-user-queries.mdx`.Closes this: 
Validated with E2E tests: 

<!-- Provide a clear summary of the changes made. -->

# Pull Request Checklist
- [ ] I have referenced the issue in the PR [description (or comments)](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I have requested a reviewer to this PR.
- [ ] I have added myself as the assignee.
- [ ] Added `hotfix` label if this PR is a critical fix that needs to be merged without approval.
